### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,41 +19,41 @@ function get(obj, parts) {
 function applyPatch(myPackageJson, patch, fromPackageJson, toPackageJson) {
   if (arguments.length > 2) {
     patch = patch.slice();
-    
+
     for (let patchIndex = 0; patchIndex < patch.length; patchIndex++) {
       let op = patch[patchIndex];
       if (op.op !== 'add') {
         continue;
       }
-      
+
       let parts = op.path.substr(1).split('/');
       let addKey = parts.pop();
       let toObj = get(toPackageJson, parts);
       let myObj = get(myPackageJson, parts);
-      
+
       if (!myObj || Array.isArray(myObj)) {
         continue;
       }
-      
+
       let toKeys = Object.keys(toObj);
       let myKeys = Object.keys(myObj);
-      
+
       let indexInTo = toKeys.indexOf(addKey);
       let indexInMy = myKeys.indexOf(addKey);
-      
+
       if (indexInMy !== -1) {
         continue;
       }
-      
+
       // we should probably add a search threshold here
       // so we don't match keys really far away
-      
+
       // search subsequent keys for match
       for (let _indexInTo = indexInTo + 1; indexInMy === -1 && _indexInTo < toKeys.length; _indexInTo++) {
         let nextKey = toKeys[_indexInTo];
         indexInMy = myKeys.indexOf(nextKey);
       }
-      
+
       // search preceding keys for match
       for (let _indexInTo = indexInTo - 1; indexInMy === -1 && _indexInTo >= 0; _indexInTo--) {
         let prevKey = toKeys[_indexInTo];
@@ -62,14 +62,14 @@ function applyPatch(myPackageJson, patch, fromPackageJson, toPackageJson) {
           indexInMy++;
         }
       }
-      
+
       if (indexInMy === -1) {
         // default to last entry
         indexInMy = myKeys.length;
       }
-      
+
       addToObjectAtIndex(myObj, addKey, toObj[addKey], indexInMy);
-      
+
       if (parts.length) {
         let key = parts.pop();
         get(myPackageJson, parts)[key] = myObj;


### PR DESCRIPTION
### :bar_chart: Metadata *

`rfc6902-ordered` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-rfc6902-ordered

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var rfc6902 = require("rfc6902-ordered")
var obj = {}
var obj1 = {"__proto__":{"polluted":"Yes! Its Polluted"}}
let patch = [{ op: 'add', path: "/__proto__/polluted", value: "Yes! Its Polluted"}]
let ours = {};
console.log("Before : " + {}.polluted);
rfc6902.applyPatch(ours, patch, obj, obj1);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i rfc6902-ordered # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/104119779-f3a6ff00-5357-11eb-8db3-0118b02a990d.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
